### PR TITLE
gccコマンドの挙動を改善

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,5 @@ RUN git clone https://github.com/longld/peda.git ~/peda
 RUN echo "source ~/peda/peda.py" >> $HOME/.gdbinit
 RUN echo "PS1='\e[32m\u@\h \e[35m \e[34m\w\n\e[0m\$ '" >> $HOME/.bashrc
 RUN echo "alias asm2bin=\"f(){ \gcc \\\$1 -O0 -g -o tmp && ./tmp; }; f\"" >> $HOME/.bashrc
-RUN echo "alias gcc=\"echo gcc command is disabled. use asm2bin command.\n$ asem2bin <asm file>\"" >> $HOME/.bashrc
+RUN echo "alias gcc=\"echo -e \\\"gcc command is disabled. use asm2bin command.\\n$ asm2bin <asm file>\\\"\"" >> $HOME/.bashrc
 WORKDIR /root


### PR DESCRIPTION
[人間 Cコンパイラコンテスト？｜みけCAT](https://note.com/mi_ke_cat/n/n7e2efbbad85d#87c0d032-180b-4d22-9268-ba4cbeaa1168)
で提案した修正を適用し、gccコマンドが syntax error ではなく asm2bin コマンド (asem2bin コマンドではない) の使い方を出力するようにする。